### PR TITLE
Allowed non-modifying members of Unsafe

### DIFF
--- a/Policy/DefaultApiPolicyFactory.PolicyReport.txt
+++ b/Policy/DefaultApiPolicyFactory.PolicyReport.txt
@@ -3357,7 +3357,33 @@ System.Runtime.CompilerServices
   TupleElementNamesAttribute: Denied
   TypeForwardedFromAttribute: Denied
   TypeForwardedToAttribute: Denied
-  Unsafe: Denied
+  Unsafe: Allowed
+     Add: Denied
+     AddByteOffset: Denied
+     AreSame: Allowed
+     As: Denied
+     AsPointer: Denied
+     AsRef: Denied
+     ByteOffset: Allowed
+     Copy: Denied
+     CopyBlock: Denied
+     CopyBlockUnaligned: Denied
+     Equals: Denied
+     GetHashCode: Denied
+     GetType: Denied
+     InitBlock: Denied
+     InitBlockUnaligned: Denied
+     IsAddressGreaterThan: Allowed
+     IsAddressLessThan: Allowed
+     Read: Denied
+     ReadUnaligned: Denied
+     SizeOf: Allowed
+     Subtract: Denied
+     SubtractByteOffset: Denied
+     ToString: Denied
+     Unbox: Denied
+     Write: Denied
+     WriteUnaligned: Denied
   UnsafeValueTypeAttribute: Denied
   ValueTaskAwaiter: Denied
   ValueTaskAwaiter`1: Denied

--- a/Policy/DefaultApiPolicyFactory.cs
+++ b/Policy/DefaultApiPolicyFactory.cs
@@ -407,6 +407,13 @@ namespace Unbreakable.Policy.Internal {
                 .Type(nameof(RuntimeHelpers), Neutral,
                     t => t.Member(nameof(RuntimeHelpers.InitializeArray), Allowed)
                           .Member("GetSubArray", Allowed, ArrayReturnRewriter.Default)
+                )
+                .Type("Unsafe", Neutral,
+                    t => t.Member("AreSame", Allowed)
+                          .Member("ByteOffset", Allowed)
+                          .Member("SizeOf", Allowed)
+                          .Member("IsAddressGreaterThan", Allowed)
+                          .Member("IsAddressLessThan", Allowed)
                 );
         }
 

--- a/[Core]/ApiAccess.cs
+++ b/[Core]/ApiAccess.cs
@@ -1,7 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
-using JetBrains.Annotations;
-
 namespace Unbreakable {
     public enum ApiAccess {
         Neutral,

--- a/[Core]/ApiFilterResult.cs
+++ b/[Core]/ApiFilterResult.cs
@@ -1,4 +1,3 @@
-using JetBrains.Annotations;
 using Unbreakable.Policy;
 
 namespace Unbreakable {


### PR DESCRIPTION
This pull requests allows some members of the `Unsafe` class which allows to observe the layout of an object or variables on the stack, but doesn't allow to modify memory. Therefore, it should be pretty safe to use these methods in SharpLab.