### PR TITLE
Fixed correcting branch sizes

### DIFF
--- a/Tests/PositiveTests.cs
+++ b/Tests/PositiveTests.cs
@@ -88,5 +88,32 @@ namespace Unbreakable.Tests {
             ", "Program", "M");
             m();
         }
+
+        [Fact]
+        public void ComputesIlOffsetsCorrectly2() {
+            var m = TestHelper.RewriteAndGetMethodWrappedInScope(@"
+                class Program {
+                    void M() {
+                        bool cond = true;
+                        if (cond)
+                            goto l1;
+                        if (cond)
+                            goto l2;
+                        M2();
+                        // produce as many nops as necessary
+                        ;;;;;;;;;; ;;;;;;;;;;
+                        ;;;;;;;;;; ;;;;;;;;;;
+                        ;;;;;;;;;; ;;;;;;;;;;
+                        ;;;;;;;;;; ;;;;;;;;;;
+                        ;;;;;;;;;; ;;;;;;;;;;
+                        ;;;;;;;
+                    l1: ;;;;;;;
+                    l2: ;
+                    }
+                    void M2() {}
+                }
+            ", "Program", "M");
+            m();
+        }
     }
 }

--- a/Tests/PositiveTests.cs
+++ b/Tests/PositiveTests.cs
@@ -64,5 +64,29 @@ namespace Unbreakable.Tests {
             });
             Assert.NotNull(m());
         }
+
+        [Fact]
+        public void ComputesIlOffsetsCorrectly() {
+            var m = TestHelper.RewriteAndGetMethodWrappedInScope(@"
+                class Program {
+                    void M() {
+                        bool cond = true;
+                        if (cond)
+                        {
+                            M2();
+                            // produce as many nops as necessary
+                            ;;;;;;;;;; ;;;;;;;;;;
+                            ;;;;;;;;;; ;;;;;;;;;;
+                            ;;;;;;;;;; ;;;;;;;;;;
+                            ;;;;;;;;;; ;;;;;;;;;;
+                            ;;;;;;;;;; ;;;;;;;;;;
+                            ;;;;;;;;;; ;;;
+                        }
+                    }
+                    void M2() {}
+                }
+            ", "Program", "M");
+            m();
+        }
     }
 }

--- a/[Core]/Internal/CecilExtensions.cs
+++ b/[Core]/Internal/CecilExtensions.cs
@@ -121,8 +121,8 @@ namespace Unbreakable.Internal {
         private static void CorrectBranchSizes(ILProcessor il) {
             var offset = 0;
             foreach (var instruction in il.Body.Instructions) {
-                offset += instruction.GetSize();
                 instruction.Offset = offset;
+                offset += instruction.GetSize();
             }
 
             foreach (var instruction in il.Body.Instructions) {


### PR DESCRIPTION
When using Unbreakable on some async code (see https://github.com/ashmind/Unbreakable/issues/1#issuecomment-755337116), I got InvalidProgramException. This happens when, after AssemblyGuard's rewrite, there is a `br.s` instruction that jumps just over the limit of 127 bytes. Because Unbreakable computes IL offsets incorrectly, it decides the instruction does not need to be modified to `br`, even when it has to be.

The added test gets into the same situation by inserting over 100 `nop` instructions using empty statements. Without this fix, the test fails for me with:

```
    System.InvalidProgramException : Common Language Runtime detected an invalid program.
  Stack Trace: 
    Program.M()
```